### PR TITLE
Remove docs from header and footer navs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,10 +105,6 @@ const config = {
             'data-umami-event-source': 'navbar',
           },
           {
-            label: 'Docs',
-            href: 'https://docs.codex.storage',
-          },
-          {
             label: 'Blog',
             href: 'https://blog.codex.storage',
           },
@@ -155,10 +151,6 @@ const config = {
           },
           {
             items: [
-              {
-                href: 'https://docs.codex.storage',
-                label: 'Docs',
-              },
               {
                 href: 'https://github.com/codex-storage',
                 label: 'Github',


### PR DESCRIPTION
### Description:
Removes `docs` links from both header and footer navs